### PR TITLE
Fixes for RHOSP17 to RHOSO18 adoption

### DIFF
--- a/roles/edpm_cisco_opflex_agent/defaults/main.yml
+++ b/roles/edpm_cisco_opflex_agent/defaults/main.yml
@@ -50,8 +50,6 @@ edpm_cisco_opflex_common_volumes:
     - "/run/openvswitch:/run/openvswitch:shared,z"
     - "/etc/opflex-agent-ovs/opflex_supervisord.conf:/etc/opflex-agent-ovs/opflex_supervisord.conf:ro"
     - "{{ edpm_cisco_opflex_agent_config_dir }}:/var/lib/kolla/config_files/src:ro"
-    - "{{ edpm_cisco_opflex_agent_neutron_dir }}/etc/neutron/neutron.conf:/etc/neutron/neutron.conf:ro"
-    - "{{ edpm_cisco_opflex_agent_neutron_dir }}/etc/neutron/metadata_agent.ini:/etc/neutron/metadata_agent.ini:ro"
     - "/var/log/containers/opflex:/var/log/opflex"
     - "/var/log/containers/neutron:/var/log/neutron"
     - "/var/run/openvswitch/:/var/run/openvswitch/:shared,z"

--- a/roles/edpm_cisco_opflex_agent/tasks/install.yml
+++ b/roles/edpm_cisco_opflex_agent/tasks/install.yml
@@ -117,14 +117,29 @@
   register: intf_out
   ignore_errors: true
   become: true
-- set_fact:
-     intf_json: "{{ intf_out.stdout | regex_search('{(?:[^{}])*}', multiline=True) | to_json }}"
+
+- name: parse interface JSON safely
+  set_fact:
+    intf_dict: "{{ (intf_out.stdout | regex_search('{[^{}]*}') | default({}, true) | from_json) }}"
+  when:
+    - intf_out is defined
+    - intf_out.rc == 0
+    - intf_out.stdout is defined
+    - intf_out.stdout | length > 0
+
+- name: set empty dict if command failed
+  set_fact:
+    intf_dict: {}
+  when: intf_dict is not defined
 
 - name: set aci_opflex_uplink_interface fact
   set_fact:
      aci_opflex_uplink_interface: "{{ item.value }}"
-  when: item.key is defined and item.key == edpm_cisco_opflex_agent_aci_opflex_uplink_interface
-  with_dict: "{{ intf_json | from_json }}"
+  when:
+    - intf_dict | length > 0
+    - item.key is defined
+    - item.key == edpm_cisco_opflex_agent_aci_opflex_uplink_interface
+  with_dict: "{{ intf_dict | dict2items }}"
 
 - set_fact:
      aci_opflex_uplink_interface: "{{ edpm_cisco_opflex_agent_aci_opflex_uplink_interface }}"


### PR DESCRIPTION
Removed references to neutron configuration files, and fixed plays to support getting non-real interfaces, such as bonds.