### PR TITLE
Fix opflex connection monitoring

### DIFF
--- a/roles/edpm_cisco_opflex_agent/templates/opflex_supervisord.conf.j2
+++ b/roles/edpm_cisco_opflex_agent/templates/opflex_supervisord.conf.j2
@@ -41,7 +41,7 @@ stderr_logfile=NONE
 
 {% if edpm_cisco_opflex_agent_opflex_conn_monitor == true %}
 [program:monitor-opflex-conn]
-command=/bin/sh -c "sleep 120; while true; do if ! sudo neutron-rootwrap /etc/neutron/rootwrap.conf netstat -natp | grep -q {{ edpm_cisco_opflex_agent_opflex_peer_port }}; then sleep 60; if ! sudo neutron-rootwrap /etc/neutron/rootwrap.conf netstat -natp | grep -q {{ edpm_cisco_opflex_agent_opflex_peer_port }}; then date >> /var/lib/opflex-agent-ovs/restarts/reset.conf; fi; sleep 60; fi; done"
+command=/bin/sh -c "sleep 120; while true; do if ! sudo neutron-rootwrap /etc/neutron/rootwrap.conf netstat -natp | grep -q {{ edpm_cisco_opflex_agent_opflex_peer_port }}; then sleep 60; if ! sudo neutron-rootwrap /etc/neutron/rootwrap.conf netstat -natp | grep -q {{ edpm_cisco_opflex_agent_opflex_peer_port }}; then date >> /var/lib/opflex-agent-ovs/restarts/reset.conf; fi; fi; sleep 60; done"
 {% endif %}
 
 [program:monitor-ovs]


### PR DESCRIPTION
If the connection is good, then the monitor runs in a tight loop. Change that to ensure that sleeps are done in between the initial checks.